### PR TITLE
Fix: Update 'three' dependency to resolve ERESOLVE error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "framer-motion": "^12.12.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "three": "^0.137.0"
+        "three": "^0.139.2"
       },
       "devDependencies": {
         "@tsconfig/recommended": "^1.0.8",
@@ -4488,10 +4488,9 @@
       }
     },
     "node_modules/three": {
-      "version": "0.137.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.137.0.tgz",
-      "integrity": "sha512-rzSDhia6cU35UCy6y+zEEws6vSgytfHqFMSaBvUcySgzwvDO6vETyswtSNi/+aVqJw8WLMwyT1mlQQ1T/dxxOA==",
-      "license": "MIT"
+      "version": "0.139.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.139.2.tgz",
+      "integrity": "sha512-gV7q7QY8rogu7HLFZR9cWnOQAUedUhu2WXAnpr2kdXZP9YDKsG/0ychwQvWkZN5PlNw9mv5MoCTin6zNTXoONg=="
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.5.24",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "framer-motion": "^12.12.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "three": "^0.137.0"
+    "three": "^0.139.2"
   },
   "devDependencies": {
     "@tsconfig/recommended": "^1.0.8",


### PR DESCRIPTION
The version of 'three' was pinned to ^0.137.0, but the @react-three/fiber@8.0.0 package requires three@>=0.139.

This commit updates 'three' to ^0.139.2 in package.json and regenerates package-lock.json by running 'npm install'.

This should resolve the ERESOLVE error encountered during the 'npm ci' step in the GitHub Actions workflow, allowing the build and deployment to proceed.