### PR TITLE
Fix(workflow): Remove overwrite of Vite-generated index.html

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,6 @@ jobs:
           npm run build
           touch dist/.nojekyll
           cp public/404.html dist/
-          cp public/index.html dist/
 
       - name: Setup Pages
         uses: actions/configure-pages@v4


### PR DESCRIPTION
The build step in the GitHub Actions workflow previously included a `cp public/index.html dist/` command. This incorrectly overwrote the `index.html` file generated by `npm run build` (Vite) with the raw, unprocessed index.html from the public directory.

This prevented the Vite-processed index.html, which includes correctly prefixed asset paths and injected script/style tags, from being deployed. This likely resulted in a 404 or a non-functional page.

This commit removes the erroneous `cp` command, allowing the Vite-generated `dist/index.html` to be deployed as intended.